### PR TITLE
Add an option to display the actual current line number

### DIFF
--- a/lib/relative-numbers.coffee
+++ b/lib/relative-numbers.coffee
@@ -1,6 +1,8 @@
 {$} = require 'atom'
 
 module.exports =
+  configDefaults:
+    displayTrueLineNumberOnCurrentLine: false
 
   activate: (state) ->
     atom.workspaceView.eachEditorView (editorView) =>
@@ -17,7 +19,13 @@ module.exports =
 
   _recalculateLineNumbers: (currentLineNumber, totalLines) ->
     currentRow = @_getRowElementByLineNumber(currentLineNumber)
-    @_setNewRowNumber(currentRow, 0)
+
+    if atom.config.get("relative-numbers.displayTrueLineNumberOnCurrentLine")
+      trueLineNumber = currentLineNumber + 1
+      @_setNewRowNumber(currentRow, trueLineNumber)
+    else
+      @_setNewRowNumber(currentRow, 0)
+
     @_recalculateBeforeCurrentRow(currentLineNumber)
     @_recalculateAfterCurrentRow(currentLineNumber, totalLines)
 

--- a/lib/relative-numbers.coffee
+++ b/lib/relative-numbers.coffee
@@ -1,14 +1,19 @@
 {$} = require 'atom'
-events = [ 'core:move-up', 'vim-mode:move-up', 'core:move-down', 'vim-mode:move-down' ]
 
 module.exports =
 
   activate: (state) ->
-    atom.workspaceView.eachEditorView (editor) =>
-      @_recalculateLineNumbers(editor.getEditor().getCursorScreenRow(), editor.getEditor().getLineCount())
-      editor.on events.join(' '), =>
+    atom.workspaceView.eachEditorView (editorView) =>
+      currentLineNumber = editorView.getEditor().getCursorScreenRow()
+      totalLines = editorView.getEditor().getLineCount()
+      @_recalculateLineNumbers(currentLineNumber, totalLines)
+
+      events = [ 'core:move-up', 'vim-mode:move-up', 'core:move-down', 'vim-mode:move-down' ]
+      editorView.on events.join(' '), =>
         atom.workspaceView.eachEditorView (editorView) =>
-          @_recalculateLineNumbers(editorView.getEditor().getCursorScreenRow(), editorView.getEditor().getLineCount())
+          currentLineNumber = editorView.getEditor().getCursorScreenRow()
+          totalLines = editorView.getEditor().getLineCount()
+          @_recalculateLineNumbers(currentLineNumber, totalLines)
 
   _recalculateLineNumbers: (currentLineNumber, totalLines) ->
     currentRow = @_getRowElementByLineNumber(currentLineNumber)
@@ -20,7 +25,7 @@ module.exports =
     $('.line-number[data-screen-row="' + lineNumber + '"]')
 
   _setNewRowNumber: (rowElement, newNumber) ->
-    $(rowElement).html('&nbsp;' + newNumber + '<div class="icon-right"></div>')
+    $(rowElement).html("&nbsp;#{newNumber}<div class=\"icon-right\"></div>")
 
   _recalculateBeforeCurrentRow: (currentLineNumber) ->
     counter = 1
@@ -29,9 +34,9 @@ module.exports =
       row = @_getRowElementByLineNumber(i)
       @_setNewRowNumber(row, counter++)
 
-  _recalculateAfterCurrentRow: (currentLineNumber, totalLine) ->
+  _recalculateAfterCurrentRow: (currentLineNumber, totalLines) ->
     counter = 1
     start = currentLineNumber + 1
-    for i in [start...totalLine]
+    for i in [start...totalLines]
       row = @_getRowElementByLineNumber(i)
       @_setNewRowNumber(row, counter++)


### PR DESCRIPTION
I'm loving this package and I've noticed a few things I'd like to help out on improving. These include the event hooks.

In this pull request I began the work on refactoring the hooks as well as adding a config option to show the true line number for the current line. I'll also add some README.md changes to accompany this option.
